### PR TITLE
Document corsproxy headers and local Pages preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,4 @@
 
 - 現時点では `src/components/WeightData.tsx` にアクセストークンがハードコードされている。変更時は [docs/rule.md](docs/rule.md) のセキュリティ方針を確認する。
 - GitHub Pages 向けには `npm run export` で production build する。公開後のデータ取得はブラウザから `corsproxy.io` 経由で行う。
+- localhost で GitHub Pages 相当の確認をする場合は [README.md](README.md) と [docs/rule.md](docs/rule.md) の Local Verification を参照する。

--- a/README.md
+++ b/README.md
@@ -3,12 +3,37 @@
 
 ## Dev
 
+### Local GitHub Pages-like Check
+
+GitHub Pages と同じ静的 HTML として確認する場合は、production build を作って `dist/` を `/myweight/` 配下で配信する。
+
+```bash
+npm run export
+npm run preview:pages
+```
+
+ブラウザで以下を開く。
+
+```text
+http://localhost:4173/myweight/
+```
+
+localhost では HealthPlanet API の取得開始日時を `20260401090000` にして、API リクエスト数を抑える。GitHub Pages では `20240327000000` から取得する。
+
+`file://` で `dist/index.html` を直接開く確認は、corsproxy.io Free plan の localhost/github.io 判定と異なるため、GitHub Pages 相当の確認には使わない。
+
 ### Export for GitHub Pages
 ```bash
 npm run export
 ```
 
 `npm run export` runs the Vite production build for GitHub Pages. The deployed app fetches the latest HealthPlanet data in the browser through `corsproxy.io`.
+
+GitHub Pages の公開 URL:
+
+```text
+https://shinichi-takayanagi.github.io/myweight/
+```
 
 ### Build Only
 ```bash
@@ -19,3 +44,5 @@ npm run build
 ```bash
 npm run dev   
 ```
+
+`npm run dev` は Vite の開発サーバー確認用。GitHub Pages と同じ条件の確認には、上記の Local GitHub Pages-like Check を使う。

--- a/docs/feature.md
+++ b/docs/feature.md
@@ -21,9 +21,12 @@
 - 体脂肪率データのタグとして `6022` を指定する。
 - 画面ロード時に両データを一括取得する。
 - GitHub Pages 公開後も、画面ロード時に `corsproxy.io` 経由で最新データを取得する。
-- 2026 年 4 月 1 日 09:00:00 から現在日時までのデータを取得する。
+- localhost では 2026 年 4 月 1 日 09:00:00 から現在日時までのデータを取得する。
+- GitHub Pages では 2024 年 3 月 27 日 00:00:00 から現在日時までのデータを取得する。
 - API 仕様上の制約に合わせ、80 日ごとにリクエストを分割する。
 - 各レスポンスの `date` と `keydata` をチャート用データに変換する。
+- `corsproxy.io` への request header と `reqHeaders` を明示し、HealthPlanet から JSON を取得する意図を固定する。
+- `corsproxy.io` 経由で Brotli 圧縮 body が返った場合は `brotli-dec-wasm` で展開する。
 
 ## 日付整形
 
@@ -33,6 +36,7 @@
 ## エラー出力
 
 - API 取得エラーを console に出力する。
+- API request、response header、raw response preview、decode 試行結果を console に出力する。
 - 401 エラーはアクセストークン不正として扱う。
 - レスポンスがない axios エラーはネットワークエラーとして扱う。
 
@@ -43,6 +47,7 @@
 - `npm run export` で GitHub Pages 用の production build を実行する。
 - `npm run lint` で ESLint を実行する。
 - `npm run preview` で build 結果をプレビューする。
+- `npm run preview:pages` で build 結果を GitHub Pages と同じ `/myweight/` 配下として localhost で配信する。
 
 ## 未実装・現時点で存在しない機能
 

--- a/docs/repo.md
+++ b/docs/repo.md
@@ -25,6 +25,8 @@
 ├── package.json
 ├── public/
 │   └── vite.svg
+├── scripts/
+│   └── serve-pages.mjs
 ├── src/
 │   ├── App.css
 │   ├── App.tsx
@@ -67,6 +69,12 @@ GitHub Actions の workflow を配置する。
 
 Vite の静的アセットを配置する。
 
+### `scripts/`
+
+開発・検証用の補助スクリプトを配置する。
+
+- `serve-pages.mjs`: `dist/` を GitHub Pages と同じ `/myweight/` 配下として localhost で配信する。
+
 ### `dist/`
 
 build 出力先。生成物であり、通常は手編集しない。
@@ -88,6 +96,7 @@ npm 依存関係のインストール先。手編集しない。
 - `export`: production build を実行する。
 - `lint`: ESLint を実行する。
 - `preview`: Vite preview を起動する。
+- `preview:pages`: `scripts/serve-pages.mjs` で GitHub Pages 相当の localhost 確認サーバーを起動する。
 
 ### `vite.config.ts`
 
@@ -122,9 +131,12 @@ ESLint 設定を定義する。
 - `react`
 - `react-dom`
 - `axios`
+- `brotli-dec-wasm`
 - `moment`
 - `recharts`
 - `cors`
+
+`brotli-dec-wasm` は、`corsproxy.io` 経由で `Content-Encoding` が欠落した Brotli 圧縮 body が返った場合に、ブラウザ上で HealthPlanet レスポンスを展開するために使用する。
 
 主な dev dependencies:
 

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -78,6 +78,19 @@ npm run build
 - API の入力日時は `YYYYMMDDHHmmss` 形式で扱う。
 - 画面表示用の日付は `YYYY/MM/DD` 形式で扱う。
 - 開発時・production build ともに `corsproxy.io` 経由で HealthPlanet API にアクセスする。
+- `corsproxy.io` 経由の HealthPlanet API 取得では、ブラウザ request header と `corsproxy.io` の `reqHeaders` を明示する。
+- ブラウザから直接指定できない `Accept-Encoding` は、`corsproxy.io` の `reqHeaders=accept-encoding:identity` で origin fetch 側に指定する。
+- `corsproxy.io` 経由のレスポンスは `arraybuffer` として受け取り、JSON parse と必要な展開処理を明示的に行う。
+- Brotli 展開の互換性は `brotli-dec-wasm` で担保する。
+
+## Local Verification
+
+- GitHub Pages と同じ条件を確認する場合は、`npm run export` で production build を作成する。
+- build 後の `dist/` は `npm run preview:pages` で `/myweight/` 配下として localhost で配信して確認する。
+- 確認 URL は `http://localhost:4173/myweight/` のように `localhost` hostname を使う。
+- `file://` で `dist/index.html` を直接開く方法は、corsproxy.io Free plan の localhost/github.io 判定と異なるため、正常系確認には使わない。
+- localhost の実 API 確認では取得開始日時を `20260401090000` とし、リクエスト数を抑える。
+- GitHub Pages では取得開始日時を `20240327000000` とする。
 
 ## セキュリティと設定値
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -22,7 +22,7 @@
 
 - データ取得元は HealthPlanet の Innerscan API。
 - 開発時・production build ともに、CORS 回避のため `corsproxy.io` 経由で HealthPlanet にリクエストする。
-- リクエスト先は `https://corsproxy.io/?url=https://www.healthplanet.jp/status/innerscan.json` とする。
+- リクエスト先は `https://corsproxy.io/?url=...` を基本とし、`reqHeaders` で HealthPlanet origin fetch 側の request header を明示する。
 - `corsproxy.io` を使うことで、GitHub Pages 公開後も画面ロード時に最新データを取得する。
 - `corsproxy.io` の設定で GitHub Pages の公開ドメインを Allowed Domains に登録する必要がある。
 - データは常に HealthPlanet API からライブ取得する。
@@ -30,6 +30,13 @@
 - `npm run export` / GitHub Pages deploy のタイミングで取得したデータを同梱して表示する仕様にはしない。
 - HTTP メソッドは POST。
 - production build でも HealthPlanet 向けパラメータは URL query ではなく `application/x-www-form-urlencoded` の POST body で送信する。
+- ブラウザから `corsproxy.io` へ送る request header は以下。
+  - `Accept: application/json`
+  - `Content-Type: application/x-www-form-urlencoded;charset=UTF-8`
+- `corsproxy.io` から HealthPlanet へ送る request header は `reqHeaders` query parameter で以下を指定する。
+  - `accept:application/json`
+  - `accept-encoding:identity`
+- ブラウザ JavaScript から `Accept-Encoding` header は直接指定できないため、origin fetch 側の圧縮制御は `corsproxy.io` の `reqHeaders` で指定する。
 - 送信パラメータは以下。
   - `access_token`
   - `date=1`
@@ -41,9 +48,24 @@
 - 画面ロード時に体重と体脂肪率を一括取得する。
 - 開発時のみ、`?fixture=success` を付けると正常系表示確認用の fixture データを使用する。
 - API の 1 回あたりの取得期間は最大 80 日として分割する。
-- 取得開始日時は `20260401090000`。
+- 取得開始日時は実行環境により切り替える。
+  - `localhost`、`127.0.0.1`、`::1`: `20260401090000`
+  - GitHub Pages など localhost 以外: `20240327000000`
 - 取得終了日時は実行時点の現在日時。
 - 各チャンクは前回の `to` の 1 秒後から次の `from` を開始する。
+
+## レスポンスデコード仕様
+
+- HealthPlanet のレスポンス本文は JSON として扱う。
+- `corsproxy.io` 経由では `Content-Encoding` が欠落した Brotli 圧縮済み body が返ることがある。
+- axios は `responseType: 'arraybuffer'` で受け取り、以下の順に JSON parse を試みる。
+  - identity
+  - gzip
+  - deflate
+  - deflate-raw
+  - Brotli via `brotli-dec-wasm`
+- Brotli 展開に成功した場合、ログ上の `decodedFormat` は `br-wasm` となる。
+- Brotli decoder は `corsproxy.io` 側の header 挙動が変動した場合の保険として維持する。
 
 ## データ形式
 
@@ -80,6 +102,7 @@ type MeasurementData = {
 ## エラー処理
 
 - API 取得に失敗した場合は console にエラーを出力する。
+- request URL、request header、corsproxy.io の `reqHeaders`、response header、decode 試行結果を console に出力する。
 - axios エラーでレスポンスがあり、HTTP ステータスが 401 または本文に `Error 401` が含まれる場合は HealthPlanet 認証エラーとして扱う。
 - axios エラーでレスポンスがない場合は `Network Error: Could not connect to the server.` を投げる。
 - 取得に失敗した測定項目は空データとして扱い、画面には空状態を表示する。
@@ -90,4 +113,6 @@ type MeasurementData = {
 - アクセストークンは `src/components/WeightData.tsx` にハードコードされている。
 - `WeightData.tsx` はモジュール読み込み時に top-level await でデータ取得を開始する。
 - 実 API 取得は開発時・production build ともに `corsproxy.io` 経由で行う。
+- GitHub Pages と同じ静的 HTML 条件を localhost で確認する場合は、`npm run export` 後に `npm run preview:pages` で `dist/` を `/myweight/` 配下として配信し、`http://localhost:4173/myweight/` のような URL で開く。
+- `file://` で `dist/index.html` を直接開く方法は、corsproxy.io の localhost/github.io 判定と異なるため、GitHub Pages 相当の正常系確認には使わない。
 - `src/main.tsx` の先頭に `<script src="http://localhost:8097"></script>` が含まれている。TypeScript/TSX としては通常の import 文ではないため、ビルドや型チェック時の注意点である。

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "tsc && vite build",
     "export": "npm run build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "preview:pages": "node scripts/serve-pages.mjs"
   },
   "dependencies": {
     "axios": "^1.6.8",

--- a/scripts/serve-pages.mjs
+++ b/scripts/serve-pages.mjs
@@ -1,0 +1,83 @@
+import { createServer } from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+const port = Number(process.env.PORT || 4173);
+const basePath = '/myweight';
+const distDir = path.resolve('dist');
+
+const contentTypes = new Map([
+  ['.css', 'text/css; charset=utf-8'],
+  ['.html', 'text/html; charset=utf-8'],
+  ['.js', 'text/javascript; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.svg', 'image/svg+xml'],
+  ['.wasm', 'application/wasm'],
+]);
+
+const getContentType = (filePath) => {
+  return contentTypes.get(path.extname(filePath)) || 'application/octet-stream';
+};
+
+const getFilePath = async (pathname) => {
+  if (pathname === basePath) {
+    return { redirect: `${basePath}/` };
+  }
+
+  if (pathname === `${basePath}/`) {
+    return { filePath: path.join(distDir, 'index.html') };
+  }
+
+  if (!pathname.startsWith(`${basePath}/`)) {
+    return null;
+  }
+
+  const relativePath = pathname.slice(basePath.length + 1);
+  const filePath = path.join(distDir, relativePath);
+  const relativeFromDist = path.relative(distDir, filePath);
+  if (relativeFromDist.startsWith('..') || path.isAbsolute(relativeFromDist)) {
+    return null;
+  }
+
+  try {
+    const fileStat = await stat(filePath);
+    if (fileStat.isFile()) {
+      return { filePath };
+    }
+  } catch {
+    return { filePath: path.join(distDir, 'index.html') };
+  }
+
+  return { filePath: path.join(distDir, 'index.html') };
+};
+
+createServer(async (request, response) => {
+  try {
+    const url = new URL(request.url || '/', `http://${request.headers.host || 'localhost'}`);
+    const resolved = await getFilePath(decodeURIComponent(url.pathname));
+
+    if (!resolved) {
+      response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      response.end('Not found');
+      return;
+    }
+
+    if (resolved.redirect) {
+      response.writeHead(302, { Location: resolved.redirect });
+      response.end();
+      return;
+    }
+
+    const body = await readFile(resolved.filePath);
+    response.writeHead(200, {
+      'Cache-Control': 'no-store',
+      'Content-Type': getContentType(resolved.filePath),
+    });
+    response.end(body);
+  } catch (error) {
+    response.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+    response.end(error instanceof Error ? error.message : 'Internal server error');
+  }
+}).listen(port, 'localhost', () => {
+  console.log(`Serving dist at http://localhost:${port}${basePath}/`);
+});

--- a/src/components/WeightData.tsx
+++ b/src/components/WeightData.tsx
@@ -55,6 +55,8 @@ const formatToApiDate = (date: moment.Moment): string => {
 };
 
 const MAX_DAYS_PER_REQUEST = 80; // Maximum days per API request
+const LOCAL_HEALTH_PLANET_START_DATE = '20260401090000';
+const GITHUB_PAGES_HEALTH_PLANET_START_DATE = '20240327000000';
 
 const metricByTag = new Map(measurementMetrics.map(metric => [metric.tag, metric]));
 
@@ -290,6 +292,28 @@ const logHealthPlanetHeaders = (
   });
 };
 
+const buildCorsProxyUrl = (targetUrl: string): string => {
+  const url = new URL('https://corsproxy.io/');
+  url.searchParams.set('url', targetUrl);
+  url.searchParams.append('reqHeaders', 'accept:application/json');
+  url.searchParams.append('reqHeaders', 'accept-encoding:identity');
+  return url.toString();
+};
+
+const isLocalhostRuntime = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return ['localhost', '127.0.0.1', '::1'].includes(window.location.hostname);
+};
+
+const getHealthPlanetStartDateString = (): string => {
+  return isLocalhostRuntime()
+    ? LOCAL_HEALTH_PLANET_START_DATE
+    : GITHUB_PAGES_HEALTH_PLANET_START_DATE;
+};
+
 const fetchInnerScanDataSet = async (
   accessToken: string,
   from: string,
@@ -302,7 +326,7 @@ const fetchInnerScanDataSet = async (
   params.append('tag', measurementMetrics.map(metric => metric.tag).join(','));
   params.append('from', from);
   params.append('to', to);
-  const url = `https://corsproxy.io/?url=${healthPlanetUrl}`;
+  const url = buildCorsProxyUrl(healthPlanetUrl);
   const requestHeaders = {
     Accept: 'application/json',
     'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
@@ -317,6 +341,10 @@ const fetchInnerScanDataSet = async (
           healthPlanetUrl,
           proxyUrl: url,
           headers: requestHeaders,
+          corsProxyRequestHeaderOverrides: {
+            accept: 'application/json',
+            'accept-encoding': 'identity',
+          },
           forbiddenBrowserHeaders: ['Accept-Encoding'],
           params: {
             access_token: maskAccessToken(accessToken),
@@ -428,13 +456,18 @@ const fetchInnerScanDataSet = async (
 };
 
 const fetchMeasurementDataSet = async (accessToken: string): Promise<MeasurementDataSet> => {
-  const startDate = moment('20260401090000', 'YYYYMMDDHHmmss');
+  const startDateString = getHealthPlanetStartDateString();
+  const startDate = moment(startDateString, 'YYYYMMDDHHmmss');
   const endDate = moment(); // Current date and time
   const allData = createEmptyMeasurementDataSet();
 
   let currentFrom = startDate.clone(); // Use clone() to avoid modifying the original startDate
 
   try {
+    console.log(
+      `HealthPlanet fetch starts at ${startDateString} (${isLocalhostRuntime() ? 'localhost' : 'production'})`
+    );
+
     while (currentFrom.isBefore(endDate)) {
       // Calculate the 'to' date for this chunk (max 80 days)
       let currentTo = currentFrom.clone().add(MAX_DAYS_PER_REQUEST, 'days');


### PR DESCRIPTION
## Summary
- add corsproxy.io request header overrides and environment-specific HealthPlanet start dates
- add a GitHub Pages-like localhost preview command for /myweight/
- update README, AGENTS, and docs to reflect the current live-fetch/Brotli behavior

## Verification
- npm run lint
- npm run export
- localhost static check at /myweight/ showed latest data and Records 29